### PR TITLE
Merge feature fix

### DIFF
--- a/src/main/matlab/+sa_labs/+analysis/+app/OfflineAnalaysisManager.m
+++ b/src/main/matlab/+sa_labs/+analysis/+app/OfflineAnalaysisManager.m
@@ -165,6 +165,7 @@ classdef OfflineAnalaysisManager < handle & mdepin.Bean
         end
         
         function preProcessEpochData(obj, epochDatas, functions, varargin)
+            
             % preProcessEpochData - apply list of functions to list of epochData
             % and serializes the results to disk for later lookup
             %

--- a/src/main/matlab/+sa_labs/+analysis/+dao/AnalysisFolderDao.m
+++ b/src/main/matlab/+sa_labs/+analysis/+dao/AnalysisFolderDao.m
@@ -75,12 +75,8 @@ classdef AnalysisFolderDao < sa_labs.analysis.dao.AnalysisDao & mdepin.Bean
             save(path, 'cellData');
         end
         
-        function names = findCellNames(obj, pattern, isCellDataByAmp)
+        function names = findCellNames(obj, pattern)
             
-            if nargin < 3
-                isCellDataByAmp = false;
-            end
-
             names = [];
             if isempty(pattern)
                 return;
@@ -90,22 +86,18 @@ classdef AnalysisFolderDao < sa_labs.analysis.dao.AnalysisDao & mdepin.Bean
                 pattern = obj.repository.dateFormat(pattern);
                 pattern = {[pattern '*c']};
             end
+            isCellDataByAmp = all(cellfun(@(p) any(strfind(p, 'Amp')), pattern)); 
             
             for i = 1 : numel(pattern)
                 p = pattern{i};
                 info = dir([obj.repository.analysisFolder filesep 'cellData' filesep char(p) '*.mat']);
                 fnames = arrayfun(@(d) {d.name(1 : end-4)}, info);
-                names = [fnames; names];
+                names = [fnames; names]; %#ok
             end
             
-            if isempty(names)
-                return
-            end
-            
-            indices = cellfun(@(name) any(strfind(name, '_Amp')), names);
-            if isCellDataByAmp
-                names = names(indices);
-            else
+            % Filter for cell data with out amp extension
+            if ~ isempty(names) && ~ isCellDataByAmp
+                indices = cellfun(@(name) any(strfind(name, '_Amp')), names);
                 names = names(~indices);
             end
         end

--- a/src/main/matlab/+sa_labs/+analysis/+dao/AnalysisFolderDao.m
+++ b/src/main/matlab/+sa_labs/+analysis/+dao/AnalysisFolderDao.m
@@ -95,7 +95,7 @@ classdef AnalysisFolderDao < sa_labs.analysis.dao.AnalysisDao & mdepin.Bean
                 names = [fnames; names]; %#ok
             end
             
-            % Filter for cell data with out amp extension
+            % Filter for cell data without amp extension
             if ~ isempty(names) && ~ isCellDataByAmp
                 indices = cellfun(@(name) any(strfind(name, '_Amp')), names);
                 names = names(~indices);
@@ -115,7 +115,7 @@ classdef AnalysisFolderDao < sa_labs.analysis.dao.AnalysisDao & mdepin.Bean
             end
         end
         
-        function saveAnalysisResults(obj, resultId, result, protocol)
+        function saveAnalysisResults(obj, resultId, result, protocol) %#ok
             dir = [obj.repository.analysisFolder filesep 'analysisTrees' filesep];
             if ~ exist(dir, 'dir')
                 mkdir(dir);
@@ -137,18 +137,17 @@ classdef AnalysisFolderDao < sa_labs.analysis.dao.AnalysisDao & mdepin.Bean
                 p = pattern{i};
                 info = dir([obj.repository.analysisFolder filesep 'analysisTrees' filesep '*' char(p) '*.mat']);
                 fnames = arrayfun(@(d) {d.name(1 : end-4)}, info);
-                names = [fnames; names];
+                names = [fnames; names]; %#ok
             end
         end
         
         function result = findAnalysisResult(obj, resultId)
-            r = [];
             path = [obj.repository.analysisFolder filesep 'analysisTrees' filesep resultId];
             r = load(path);
             result = r.result;
         end
         
-        function saveCellDataFilter(obj, filterName, filterTable)
+        function saveCellDataFilter(obj, filterName, filterTable) %#ok
             dir = [obj.repository.analysisFolder filesep 'filters' filesep 'cellData' filesep];
             if ~ exist(dir, 'dir')
                 mkdir(dir);

--- a/src/main/matlab/+sa_labs/+analysis/+entity/EpochData.m
+++ b/src/main/matlab/+sa_labs/+analysis/+entity/EpochData.m
@@ -65,7 +65,7 @@ classdef EpochData < sa_labs.analysis.entity.KeyValueEntity
         function r = getResponse(obj, device)
             
             % getResponse - finds the device response by executing call back
-            % 'responseHandle(fname, path)'
+            % 'responseHandle(path)'
             % path - is obtained from dataLinks by matching it with given
             % device @ see symphony2parser.parse() method for responseHandle
             % definition

--- a/src/main/matlab/+sa_labs/+analysis/+entity/EpochData.m
+++ b/src/main/matlab/+sa_labs/+analysis/+entity/EpochData.m
@@ -7,6 +7,7 @@ classdef EpochData < sa_labs.analysis.entity.KeyValueEntity
     properties (Transient)
         filtered              % used to filter epochs from GUI  
         inMemoryAttributes    % used to visualize derived response but not crucial to store  
+        excluded              % used to delete the epochs  
     end
     
     properties (Hidden)
@@ -21,6 +22,7 @@ classdef EpochData < sa_labs.analysis.entity.KeyValueEntity
             obj.dataLinks = containers.Map();
             obj.derivedAttributes = containers.Map();
             obj.filtered = true;
+            obj.excluded = false;
         end
         
         function v = get(obj, key)

--- a/src/main/matlab/+sa_labs/+analysis/+entity/EpochData.m
+++ b/src/main/matlab/+sa_labs/+analysis/+entity/EpochData.m
@@ -1,13 +1,12 @@
 classdef EpochData < sa_labs.analysis.entity.KeyValueEntity
     
     properties
-        parentCell            % parent cell
-        excluded              % soft delete epoch  
+        parentCell            % parent cell see @ sa_labs.analysis.entity.CellData
     end
 
     properties (Transient)
         filtered              % used to filter epochs from GUI  
-        inMemoryAttributes
+        inMemoryAttributes    % used to visualize derived response but not crucial to store  
     end
     
     properties (Hidden)
@@ -21,7 +20,6 @@ classdef EpochData < sa_labs.analysis.entity.KeyValueEntity
         function obj = EpochData()
             obj.dataLinks = containers.Map();
             obj.derivedAttributes = containers.Map();
-            obj.excluded = false;
             obj.filtered = true;
         end
         
@@ -65,7 +63,7 @@ classdef EpochData < sa_labs.analysis.entity.KeyValueEntity
         function r = getResponse(obj, device)
             
             % getResponse - finds the device response by executing call back
-            % 'responseHandle(path)'
+            % 'responseHandle(fname, path)'
             % path - is obtained from dataLinks by matching it with given
             % device @ see symphony2parser.parse() method for responseHandle
             % definition
@@ -152,7 +150,7 @@ classdef EpochData < sa_labs.analysis.entity.KeyValueEntity
 
         function deviceType = getDefaultDeviceType(obj)
             deviceType = [];
-            if ~ isempty(obj.parentCell) && ~ isempty(obj.parentCell.deviceType)
+            if ~ isempty(obj.parentCell) && ~ obj.parentCell.isClusterRecording()
                 deviceType = obj.parentCell.deviceType;
             end
         end      

--- a/src/main/matlab/+sa_labs/+analysis/+entity/EpochData.m
+++ b/src/main/matlab/+sa_labs/+analysis/+entity/EpochData.m
@@ -7,13 +7,13 @@ classdef EpochData < sa_labs.analysis.entity.KeyValueEntity
     properties (Transient)
         filtered              % used to filter epochs from GUI  
         inMemoryAttributes    % used to visualize derived response but not crucial to store  
-        excluded              % used to delete the epochs  
     end
     
     properties (Hidden)
         dataLinks             % Map with keys as Amplifier device and values as responses
         responseHandle        % amplifere response call back argumet as stream name
-        derivedAttributes     % spikes and other epoch specific pre-processed data  
+        derivedAttributes     % spikes and other epoch specific pre-processed data 
+        excluded              % used to delete the epochs   
     end
     
     methods

--- a/src/main/matlab/+sa_labs/+analysis/+entity/EpochGroup.m
+++ b/src/main/matlab/+sa_labs/+analysis/+entity/EpochGroup.m
@@ -119,7 +119,7 @@ classdef EpochGroup < sa_labs.analysis.entity.Group
         end
 
         function tf = hasDevice(obj, key)
-            tf = ~ isempty(strfind(upper(key), upper(obj.device))); %#ok
+            tf = any(strfind(upper(key), upper(obj.device)));
         end
 
         function key = makeValidKey(obj, key)

--- a/src/main/matlab/+sa_labs/+analysis/+entity/Feature.m
+++ b/src/main/matlab/+sa_labs/+analysis/+entity/Feature.m
@@ -38,7 +38,9 @@ classdef Feature < handle & matlab.mixin.Heterogeneous
                 obj.downSampled = false;
             end
             d = obj.formatData(d);
-            
+            if isempty(d)
+                d = {[]};
+            end
         end
         
         function obj = set.data(obj, d)

--- a/src/main/matlab/+sa_labs/+analysis/+parser/SymphonyV1Parser.m
+++ b/src/main/matlab/+sa_labs/+analysis/+parser/SymphonyV1Parser.m
@@ -66,6 +66,7 @@ classdef SymphonyV1Parser < sa_labs.analysis.parser.SymphonyParser
                 epoch = entity.EpochData();
                 epoch.attributes('epochStartTime') = epochTimes_sorted(i);
                 epoch.attributes('epochNum') = i;
+                epoch.attributes('epochTime') = util.dotnetTicksToDateTime(epochTimes(groupInd));
                 epoch.parentCell = data;
                 epoch.attributes = obj.mapAttributes(EpochDataGroups(groupInd).Groups(1), epoch.attributes);
                 epoch.dataLinks = obj.addDataLinks(EpochDataGroups(groupInd).Groups(2).Groups);
@@ -74,7 +75,7 @@ classdef SymphonyV1Parser < sa_labs.analysis.parser.SymphonyParser
                 data.epochs(i) = epoch;
             end
             data.attributes('Nepochs') = nEpochs;
-            data.h5File = obj.fname;
+            data.attributes('h5File') = obj.fname;
             obj.addCellDataByAmps(data);
         end
         

--- a/src/test/matlab/+sa_labs/+analysis/+app/OfflineAnalysisManagerTest.m
+++ b/src/test/matlab/+sa_labs/+analysis/+app/OfflineAnalysisManagerTest.m
@@ -196,8 +196,8 @@ classdef OfflineAnalysisManagerTest < matlab.unittest.TestCase
             cellDatas = sa_labs.analysis.entity.CellData.empty(0, n);
             for i = 1 : n
                 cellDatas(i) = sa_labs.analysis.entity.CellData();
-                cellDatas(i).h5File = file;
-                cellDatas(i).recordingLabel = labels{i};
+                cellDatas(i).attributes('h5File') = file;
+                cellDatas(i).attributes('recordingLabel') = labels{i};
             end
         end 
     end

--- a/src/test/matlab/+sa_labs/+analysis/+dao/DaoTest.m
+++ b/src/test/matlab/+sa_labs/+analysis/+dao/DaoTest.m
@@ -164,7 +164,7 @@ classdef DaoTest < matlab.unittest.TestCase
             obj.verifyEmpty(setdiff(expected, actual));
             
             % Test for Amp extension cell data names
-            names = dao.findCellNames(cellstr('cluster-c1'), true);
+            names = dao.findCellNames(cellstr('cluster-c1*Amp1'));
             obj.verifyEqual(names, cellstr('cluster-c1_Amp1'));
             
             names = dao.findCellNames(cellstr('cluster-c1'));

--- a/src/test/matlab/+sa_labs/+analysis/+dao/DaoTest.m
+++ b/src/test/matlab/+sa_labs/+analysis/+dao/DaoTest.m
@@ -38,8 +38,8 @@ classdef DaoTest < matlab.unittest.TestCase
                 h5create(path ,'/ds' , [10 20]);
                 h5writeatt(path, '/','version', 1);
                 cellData = sa_labs.analysis.entity.CellData();
-                cellData.h5File = path;
-                cellData.recordingLabel = '';
+                cellData.attributes('h5File') = path;
+                cellData.attributes('recordingLabel') = '';
                 obj.testCellDatas(i) = cellData;
                 obj.cellNames{i} = cellData.recordingLabel;
             end
@@ -75,7 +75,7 @@ classdef DaoTest < matlab.unittest.TestCase
             % Test for cellDataByAmp
             import sa_labs.analysis.*;
             cellData = entity.CellData();
-            cellData.recordingLabel = 'cluster-c1';
+            cellData.attributes('recordingLabel') = 'cluster-c1';
             cellDataByAmp = entity.CellDataByAmp(cellData.recordingLabel, 'Amp1');
             dao.saveCell(cellData);
             dao.saveCell(cellDataByAmp);

--- a/src/test/matlab/+sa_labs/+analysis/+entity/EpochGroupTest.m
+++ b/src/test/matlab/+sa_labs/+analysis/+entity/EpochGroupTest.m
@@ -28,23 +28,29 @@ classdef EpochGroupTest < matlab.unittest.TestCase
             epochs(1).responseHandle = @(arg) struct('quantity', [1:10]);
             epochs(1).addDerivedResponse('spikes', 1 : 5, 'Amp1');
             epochs(1).addDerivedResponse('spikes', 1 : 8, 'Amp2');
+            epochs(1).addDerivedResponse('someFeature', 1 : 5, 'Amp1');
+            epochs(1).addDerivedResponse('someFeature', [], 'Amp2');
 
             epochs(2) = entity.EpochData();
             epochs(2).dataLinks = containers.Map({'Amp1', 'Amp2' }, {'response1', 'response2'});
             epochs(2).responseHandle = @(arg) struct('quantity', [11:20]);
             epochs(2).addDerivedResponse('spikes', 1 : 3, 'Amp1');
             epochs(2).addDerivedResponse('spikes', 1 : 6, 'Amp2');
-
+            epochs(2).addDerivedResponse('someFeature', [], 'Amp1');
+            epochs(2).addDerivedResponse('someFeature', [{1}, {2}], 'Amp2');
+            
             epochGroup = entity.EpochGroup('test', 'param');
             epochGroup.device = 'Amp1';
             epochGroup.populateEpochResponseAsFeature(epochs);
             obj.verifyEqual(epochGroup.getFeatureData('AMP1_EPOCH'), [(1:10)', (11:20)']);
             obj.verifyEqual(epochGroup.getFeatureData('AMP1_SPIKES'), {(1:5)', (1:3)'});
-            
+            obj.verifyEqual(epochGroup.getFeatureData('AMP1_SOMEFEATURE'), {(1:5)', []});
+             
             epochGroup.device = 'Amp2';
             epochGroup.populateEpochResponseAsFeature(epochs);
             obj.verifyEqual(epochGroup.getFeatureData('AMP2_EPOCH'), [(1:10)', (11:20)']);
             obj.verifyEqual(epochGroup.getFeatureData('AMP2_SPIKES'), {(1:8)', (1:6)'});
+            obj.verifyEqual(epochGroup.getFeatureData('AMP2_SOMEFEATURE'), {{[]}, [{1}, {2}]'});
             
             epochGroup.device = '';
             % epochs are of same size

--- a/src/test/matlab/+sa_labs/+analysis/+entity/EpochGroupTest.m
+++ b/src/test/matlab/+sa_labs/+analysis/+entity/EpochGroupTest.m
@@ -36,8 +36,8 @@ classdef EpochGroupTest < matlab.unittest.TestCase
             epochs(2).responseHandle = @(arg) struct('quantity', [11:20]);
             epochs(2).addDerivedResponse('spikes', 1 : 3, 'Amp1');
             epochs(2).addDerivedResponse('spikes', 1 : 6, 'Amp2');
-            epochs(2).addDerivedResponse('someFeature', [], 'Amp1');
-            epochs(2).addDerivedResponse('someFeature', [{1}, {2}], 'Amp2');
+            epochs(2).addDerivedResponse('someFeature', {}, 'Amp1');
+            epochs(2).addDerivedResponse('someFeature', {1, 2}, 'Amp2');
             
             epochGroup = entity.EpochGroup('test', 'param');
             epochGroup.device = 'Amp1';
@@ -50,7 +50,7 @@ classdef EpochGroupTest < matlab.unittest.TestCase
             epochGroup.populateEpochResponseAsFeature(epochs);
             obj.verifyEqual(epochGroup.getFeatureData('AMP2_EPOCH'), [(1:10)', (11:20)']);
             obj.verifyEqual(epochGroup.getFeatureData('AMP2_SPIKES'), {(1:8)', (1:6)'});
-            obj.verifyEqual(epochGroup.getFeatureData('AMP2_SOMEFEATURE'), {{[]}, [{1}, {2}]'});
+            obj.verifyEqual(epochGroup.getFeatureData('AMP2_SOMEFEATURE'), {{[]}, {1,2}'});
             
             epochGroup.device = '';
             % epochs are of same size

--- a/src/test/matlab/+sa_labs/+analysis/+entity/GroupTest.m
+++ b/src/test/matlab/+sa_labs/+analysis/+entity/GroupTest.m
@@ -83,15 +83,16 @@ classdef GroupTest < matlab.unittest.TestCase
         function testFeature(obj)
             import sa_labs.analysis.entity.*;
             group = Group('root==param');
-            group.createFeature('TEST_FIRST', []);
-            feature = group.getFeatures('TEST_FIRST');
+            group.createFeature('TEST_FIRST_EMPTY', []);
+            feature = group.getFeatures('TEST_FIRST_EMPTY');
             
-            obj.verifyEmpty(feature.data);
+            obj.verifyEmpty(feature.data{:});
             
             % test append data
-            feature.appendData(1 : 1000);
+            group.createFeature('TEST_FIRST', 1 : 1000);
             obj.verifyEqual(group.getFeatures('TEST_FIRST').data, (1 : 1000)');
             
+            feature = group.getFeatures('TEST_FIRST');
             % check feature as reference object
             feature.data = feature.data + ones(1000, 1);
             obj.verifyEqual(group.getFeatures('TEST_FIRST').data, (2 : 1001)');


### PR DESCRIPTION
Example: 
```Matlab
SOME_FEATURE_ONE = [1, 2, 3, 4, 5]
SOME_FEATURE_TWO= [];
group.getFeatureData('SOME_FEATURE') will should output with two rows rather one row

Features
----------
#1 [1, 2, 3, 4, 5]
#2 []

```